### PR TITLE
Check cidr

### DIFF
--- a/mod_rpaf.c
+++ b/mod_rpaf.c
@@ -135,7 +135,7 @@ static int check_cidr(apr_pool_t *pool, const char *ipcidr, const char *testip) 
         return -1;
     }
 
-    netmask = 0xffffffff << (32 - atoi(cidr));
+    netmask = 0xffffffff << (32 - cidr_val);
     ipval = ntohl(inet_addr(ip));
     testipval = ntohl(inet_addr(testip));
 


### PR DESCRIPTION
Hi Geoffrey,

(Again, sorry for the confused pull reuqests...)

This request makes two small changes to the check_cidr function.
1. Drop an unused variable to prevent a compiler warning.
2. Re-used a computed and stored value (cidr_val) instead of recomputing it with atoi.

Thanks
-Ben
