### PR TITLE
CVE-2012-3526 fix from 030_ipv6.patch

### DIFF
--- a/mod_rpaf.c
+++ b/mod_rpaf.c
@@ -219,9 +219,10 @@ static int change_remote_ip(request_rec *r) {
 
             tmppool = r->connection->remote_addr->pool;
             tmpport = r->connection->remote_addr->port;
-            memset(r->connection->remote_addr, '\0', sizeof(apr_sockaddr_t));
-            r->connection->remote_addr = NULL;
-            apr_sockaddr_info_get(&(r->connection->remote_addr), r->connection->remote_ip, APR_UNSPEC, tmpport, 0, tmppool);
+            apr_sockaddr_t *tmpsa;
+            int ret = apr_sockaddr_info_get(&tmpsa, r->connection->remote_ip, APR_UNSPEC, tmpport, 0, tmppool);
+            if (ret == APR_SUCCESS)
+                memcpy(r->connection->remote_addr, tmpsa, sizeof(apr_sockaddr_t));
             if (cfg->sethostname) {
                 const char *hostvalue;
                 if ((hostvalue = apr_table_get(r->headers_in, "X-Forwarded-Host")) ||


### PR DESCRIPTION
We had segfaults with the master version from the repository when the nginx forwards requests with IPv6 ips to an IPv4 only apache.

Some reasearch pointed me to http://zecrazytux.net/troubleshooting/apache2-segfault-debugging-tutorial and I tried the debian patch, which fixed the problem.

You can reproduce the original problem with:
`curl -H 'X-Forwarded-For: foobar, 127.0.0.1' -v http://127.0.0.1/`

That should segfault before, but not after the commit. Replace foobar with IPv6-Address, if you like.

Please review and merge.
