### PR TITLE
Change API for Apache 2.4 Compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-## mod_rpaf - reverse proxy add forward 
+## mod_rpaf - reverse proxy add forward
 
 ### Summary
-This build is a preliminary test for Apache 2.4. Please test and tready carefully.
-
 
 Sets `REMOTE_ADDR`, `HTTPS`, and `HTTP_PORT` to the values provided by an upstream proxy.
 Sets `remoteip-proxy-ip-list` field in r->notes table to list of proxy intermediaries.

--- a/mod_rpaf.c
+++ b/mod_rpaf.c
@@ -204,8 +204,8 @@ static char *last_not_in_array(request_rec *r, apr_array_header_t *forwarded_for
     }
 
     if (i > 0 || rv == APR_SUCCESS || earliest_legit_i) {
-        /* clientip-proxy-ip_list r->notes entry is forward compatible with Apache2.4 mod_remoteip*/
-        apr_table_set(r->notes, "clientip-proxy-ip-list", proxy_list);
+        /* remoteip-proxy-ip_list r->notes entry is forward compatible with Apache2.4 mod_remoteip*/
+        apr_table_set(r->notes, "remoteip-proxy-ip-list", proxy_list);
         return fwd_ips[earliest_legit_i];
     }
     else {


### PR DESCRIPTION
These changes bring support for Apache 2.4 which is not backwards compatible with Apache 2.2. This code has been tested on Ubuntu 14.04 LTS running Apache 2.4.7.
