### PR TITLE
Cleanup "rpaf_https" connection note at the end of the request

### DIFF
--- a/mod_rpaf.c
+++ b/mod_rpaf.c
@@ -216,6 +216,7 @@ static apr_status_t rpaf_cleanup(void *data) {
     rpaf_cleanup_rec *rcr = (rpaf_cleanup_rec *)data;
     rcr->r->DEF_IP = apr_pstrdup(rcr->r->connection->pool, rcr->old_ip);
     rcr->r->DEF_ADDR->sa.sin.sin_addr.s_addr = apr_inet_addr(rcr->r->DEF_IP);
+    apr_table_unset(rcr->r->connection->notes, "rpaf_https");
     return APR_SUCCESS;
 }
 


### PR DESCRIPTION
The "rpaf_https" note was set for the connection when https-to-http forwarding was detected but
never cleaned up.

This led to two bugs:
- If a reverse proxy that performs HTTPS termination recycles a connection to the backend server
  and mixes HTTP and HTTPS requests, the first HTTPS will toggle this flag for the entire connection.
  Thus, it looks as if all subsequent requests were made over HTTPS (even for different clients).
- Due to the short-circuit at the beginning of rpaf_post_read_request, for those subsequent requests
  the client address and port would not be updated, the proxy IP and port were visible instead.

(Amazon EC's ELB exhibit this behaviour of recycling connections.)

As the initial change in 3a1aaf675b3abe7e6390a69210407464d5c415a8 seemingly only tried to fix the "HTTPS" _environment_ variable for internal subrequests made via mod_rewrite, one option would have been to store the "rpaf_https" flag in a per-request note for master requests and then look at this (via request_rec's main slot) information in subrequests.

However, the 55c8b1d8d38dbffd474c6e0f77892d083fc2a42d commit also updates the magic "HTTPS" flag originally set by mod_ssl and also available in mod_rewrite. This flag is based on a function "ssl_is_https" (modules/ssl/ssl_engine_vars.c) that looks at a conn_rec*. For mod_ssl, this probably makes sense because the entire _connection_ is either SSL or not.

With this PR, we keep the flag _on the connection_ but clean it up at the end of a request (when the request pool is freed). That way, subrequests should still work as previously with no extra processing done. The flag should remain present until the end of the _master_ request.
