### PR TITLE
Re-add rpaf.conf and update path in spec file

### DIFF
--- a/mod_rpaf.spec
+++ b/mod_rpaf.spec
@@ -27,7 +27,6 @@ make rpaf
 rm -rf $RPM_BUILD_ROOT
 install -m0755 -d $RPM_BUILD_ROOT$(apxs -q LIBEXECDIR)
 make DESTDIR=$RPM_BUILD_ROOT install
-install -m0644 -D debian/conf/rpaf.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/mod_rpaf.conf
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -45,5 +44,8 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Mon Nov 02 2015 Marc Teale <marc.teale@gmail.com> - 0.8
+- Remove reference to Debian build directory.
+
 * Mon Oct 17 2011 Ben Walton <bwalton@artsci.utoronto.ca> - 0.7
 - Initial spec file creation

--- a/mod_rpaf.spec
+++ b/mod_rpaf.spec
@@ -27,6 +27,7 @@ make rpaf
 rm -rf $RPM_BUILD_ROOT
 install -m0755 -d $RPM_BUILD_ROOT$(apxs -q LIBEXECDIR)
 make DESTDIR=$RPM_BUILD_ROOT install
+install -m0644 -D rpaf.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/mod_rpaf.conf
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -45,7 +46,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %changelog
 * Mon Nov 02 2015 Marc Teale <marc.teale@gmail.com> - 0.8
-- Remove reference to Debian build directory.
+- Update references to mod_rpaf.conf.
 
 * Mon Oct 17 2011 Ben Walton <bwalton@artsci.utoronto.ca> - 0.7
 - Initial spec file creation

--- a/rpaf.conf
+++ b/rpaf.conf
@@ -1,0 +1,8 @@
+<IfModule mod_rpaf.c>
+  RPAF_Enable       On
+  RPAF_ProxyIPs     127.0.0.1
+  RPAF_Header       X-Forwarded-For
+  RPAF_SetHostName  On
+  RPAF_SetHTTPS     On
+  RPAF_SetPort      On
+</IfModule>


### PR DESCRIPTION
The spec file is out of date and still references a removed debian directory.  This adds rpaf.conf back in and updates the the spec file.
