### PR TITLE
fix to work with apache-2.4

### DIFF
--- a/mod_rpaf.c
+++ b/mod_rpaf.c
@@ -16,9 +16,9 @@
 
 #include "ap_release.h"
 #if AP_SERVER_MAJORVERSION_NUMBER >= 2 && AP_SERVER_MINORVERSION_NUMBER >= 4
-  #define DEF_IP   useragent_ip
-  #define DEF_ADDR useragent_addr
-  #define DEF_POOL pool
+  #define DEF_IP   connection->client_ip
+  #define DEF_ADDR connection->client_addr
+  #define DEF_POOL connection->pool
 #else
   #define DEF_IP   connection->remote_ip
   #define DEF_ADDR connection->remote_addr


### PR DESCRIPTION
There is error ussing this mod on apache 2.4.18 on FreeBSD 10.2 at least.
I think mine version is more correct, because of in apache24 there was just renamed variables of apache22 remote_ip to client_ip, and remote_addr to client_addr.

In the httpd.h of apach24 there is said:

```
/** remote addres information from conn_rec, can be overridden if
 * necessary by a module.
 * This is the address that originated the request.
 */
apr_sockaddr_t *useragent_addr;
char *useragent_ip;
```

So I think thats mean we shouldn't change this values but conn_rec->client_ip and conn_rec->client_addr

Just a small patch to make it work with apache 2.4.18 on my FreeBSD 10.2 installation

Can someone test it on linux distributions?
