### PR TITLE
affects ip address even if no headers are added (no proxy)

### DIFF
--- a/mod_rpaf.c
+++ b/mod_rpaf.c
@@ -251,8 +251,8 @@ static int rpaf_post_read_request(request_rec *r) {
     int i;
     apr_port_t tmpport;
     apr_pool_t *tmppool;
-    
-    rpaf_server_cfg *cfg = (rpaf_server_cfg *)ap_get_module_config(r->server->module_config, &rpaf_module);
+    rpaf_server_cfg *cfg = (rpaf_server_cfg *)ap_get_module_config(r->server->module_config,  
+                                                                   &rpaf_module);
 
     if (!cfg->enable)
         return DECLINED;
@@ -265,7 +265,7 @@ static int rpaf_post_read_request(request_rec *r) {
     if (rpaf_https) {
         apr_table_set(r->subprocess_env, "HTTPS", rpaf_https);
         return DECLINED;
-    };
+    }
 
     /* check if the remote_addr is in the allowed proxy IP list */
     if (is_in_array(r->DEF_ADDR, cfg->proxy_ips) != 1) {

--- a/mod_rpaf.c
+++ b/mod_rpaf.c
@@ -360,15 +360,13 @@ static int rpaf_post_read_request(request_rec *r) {
         const char *portvalue;
         if ((portvalue = apr_table_get(r->headers_in, "X-Forwarded-Port")) ||
             (portvalue = apr_table_get(r->headers_in, "X-Port"))) {
-        	//// HERE
             r->server->port    = atoi(portvalue);
             r->parsed_uri.port = r->server->port;
         } else {
             r->server->port = cfg->orig_port;
         }
     }
-    
-    
+
     return DECLINED;
 }
 

--- a/mod_rpaf.c
+++ b/mod_rpaf.c
@@ -251,7 +251,7 @@ static int rpaf_post_read_request(request_rec *r) {
     int i;
     apr_port_t tmpport;
     apr_pool_t *tmppool;
-    rpaf_server_cfg *cfg = (rpaf_server_cfg *)ap_get_module_config(r->server->module_config,  
+    rpaf_server_cfg *cfg = (rpaf_server_cfg *)ap_get_module_config(r->server->module_config,
                                                                    &rpaf_module);
 
     if (!cfg->enable)

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+make && sudo make install && sudo service apache2 restart && banner "G O  !"
+tail -f /var/log/apache2/error.log
+

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-make && sudo make install && sudo service apache2 restart && banner "G O  !"
-tail -f /var/log/apache2/error.log
-


### PR DESCRIPTION
this way, the module works correctly even if it's detecting the request is not commit from a proxy. request infos are not altered strangely.
(it was affecting port 443 for direct requests, without the HTTPS flag ...)
